### PR TITLE
Fix Website Batch operations for all sessions  -- fixes #5

### DIFF
--- a/crisp/website_batch.go
+++ b/crisp/website_batch.go
@@ -5,66 +5,60 @@
 
 package crisp
 
-
 import (
-  "fmt"
+	"fmt"
 )
-
 
 // WebsiteBatchConversationsOperation mapping
 type WebsiteBatchConversationsOperation struct {
-  Sessions  *[]string  `json:"sessions,omitempty"`
+	Sessions []string `json:"sessions,omitempty"`
 }
 
 // WebsiteBatchPeopleOperation mapping
 type WebsiteBatchPeopleOperation struct {
-  People  *WebsiteBatchPeopleOperationInner  `json:"people,omitempty"`
+	People *WebsiteBatchPeopleOperationInner `json:"people,omitempty"`
 }
 
 // WebsiteBatchPeopleOperationInner mapping
 type WebsiteBatchPeopleOperationInner struct {
-  Profiles  *[]string                                `json:"profiles,omitempty"`
-  Search    *WebsiteBatchPeopleOperationInnerSearch  `json:"search,omitempty"`
+	Profiles *[]string                               `json:"profiles,omitempty"`
+	Search   *WebsiteBatchPeopleOperationInnerSearch `json:"search,omitempty"`
 }
 
 // WebsiteBatchPeopleOperationInnerSearch mapping
 type WebsiteBatchPeopleOperationInnerSearch struct {
-  Filter    []WebsiteFilter  `json:"filter,omitempty"`
-  Operator  string           `json:"operator,omitempty"`
+	Filter   []WebsiteFilter `json:"filter,omitempty"`
+	Operator string          `json:"operator,omitempty"`
 }
-
 
 // BatchResolveConversations resolves given (or all) items in website (conversation variant).
 func (service *WebsiteService) BatchResolveConversations(websiteID string, sessions []string) (*Response, error) {
-  url := fmt.Sprintf("website/%s/batch/resolve", websiteID)
-  req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: &sessions})
+	url := fmt.Sprintf("website/%s/batch/resolve", websiteID)
+	req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: sessions})
 
-  return service.client.Do(req, nil)
+	return service.client.Do(req, nil)
 }
-
 
 // BatchReadConversations marks given (or all) items as read in website (conversation variant).
 func (service *WebsiteService) BatchReadConversations(websiteID string, sessions []string) (*Response, error) {
-  url := fmt.Sprintf("website/%s/batch/read", websiteID)
-  req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: &sessions})
+	url := fmt.Sprintf("website/%s/batch/read", websiteID)
+	req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: sessions})
 
-  return service.client.Do(req, nil)
+	return service.client.Do(req, nil)
 }
-
 
 // BatchRemoveConversations removes given items in website (conversation variant).
 func (service *WebsiteService) BatchRemoveConversations(websiteID string, sessions []string) (*Response, error) {
-  url := fmt.Sprintf("website/%s/batch/remove", websiteID)
-  req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: &sessions})
+	url := fmt.Sprintf("website/%s/batch/remove", websiteID)
+	req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchConversationsOperation{Sessions: sessions})
 
-  return service.client.Do(req, nil)
+	return service.client.Do(req, nil)
 }
-
 
 // BatchRemovePeople removes given items in website (people variant).
 func (service *WebsiteService) BatchRemovePeople(websiteID string, people WebsiteBatchPeopleOperationInner) (*Response, error) {
-  url := fmt.Sprintf("website/%s/batch/remove", websiteID)
-  req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchPeopleOperation{People: &people})
+	url := fmt.Sprintf("website/%s/batch/remove", websiteID)
+	req, _ := service.client.NewRequest("PATCH", url, WebsiteBatchPeopleOperation{People: &people})
 
-  return service.client.Do(req, nil)
+	return service.client.Do(req, nil)
 }


### PR DESCRIPTION
The issue looks to be a serialization issue, where pointers to slices are serialized as `[]` instead of being picked up by the `omitempty` JSON struct tag 