### PR TITLE
allow empty `assigned` parameter in order to set assigned operator to none

### DIFF
--- a/crisp/website_conversation.go
+++ b/crisp/website_conversation.go
@@ -569,7 +569,7 @@ type ConversationOpenUpdate struct {
 
 // ConversationRoutingAssignUpdate mapping
 type ConversationRoutingAssignUpdate struct {
-  Assigned  *ConversationRoutingAssignUpdateAssigned  `json:"assigned,omitempty"`
+  Assigned  *ConversationRoutingAssignUpdateAssigned  `json:"assigned"`
 }
 
 // ConversationRoutingAssignUpdateAssigned mapping


### PR DESCRIPTION
According to the [documentation](https://docs.crisp.chat/api/v1/#website-website-conversation-patch-5), you have to pass an empty `assigned` parameter in order to set the assigned operator to none. However, this is not possible unless we remove the `omitempty` tag.

> Assigned operator (set to blank value for none)