### PR TITLE
set empty slice value

### DIFF
--- a/crisp/website_conversation.go
+++ b/crisp/website_conversation.go
@@ -812,18 +812,18 @@ type ConversationMetaUpdate struct {
   Address   string                        `json:"address,omitempty"`
   Subject   string                        `json:"subject,omitempty"`
   Origin    string                        `json:"origin,omitempty"`
-  Segments  []string                      `json:"segments,omitempty"`
+  Segments  *[]string                     `json:"segments,omitempty"`
   Data      interface{}                   `json:"data,omitempty"`
   Device    *ConversationMetaUpdateDevice `json:"device,omitempty"`
 }
 
 // ConversationMetaUpdateDevice mapping
 type ConversationMetaUpdateDevice struct {
-  Capabilities  []string                                  `json:"capabilities,omitempty"`
+  Capabilities  *[]string                                 `json:"capabilities,omitempty"`
   Geolocation   *ConversationMetaUpdateDeviceGeolocation  `json:"geolocation,omitempty"`
   System        *ConversationMetaUpdateDeviceSystem       `json:"system,omitempty"`
   Timezone      int16                                     `json:"timezone,omitempty"`
-  Locales       []string                                  `json:"locales,omitempty"`
+  Locales       *[]string                                 `json:"locales,omitempty"`
 }
 
 // ConversationMetaUpdateDeviceGeolocation mapping

--- a/crisp/website_people.go
+++ b/crisp/website_people.go
@@ -254,7 +254,7 @@ type PeopleProfileUpdateCard struct {
   Email     string                     `json:"email,omitempty"`
   Person    *PeopleProfileCardPerson   `json:"person,omitempty"`
   Company   *PeopleProfileCardCompany  `json:"company,omitempty"`
-  Segments  []string                   `json:"segments,omitempty"`
+  Segments  *[]string                  `json:"segments,omitempty"`
   Notepad   string                     `json:"notepad,omitempty"`
   Active    uint64                     `json:"active,omitempty"`
 }


### PR DESCRIPTION
Updatable slices should be pointers to allow setting empty values. Eg. removing all segments on a conversation currently does not work when setting an empty string slice.